### PR TITLE
Run long-running processes in threads

### DIFF
--- a/optimiser-controller/src/main/java/eu/nebulouscloud/optimiser/controller/LocalExecution.java
+++ b/optimiser-controller/src/main/java/eu/nebulouscloud/optimiser/controller/LocalExecution.java
@@ -76,7 +76,7 @@ public class LocalExecution implements Callable<Integer> {
             if (deploy) {
                 if (perf_msg != null) {
                     log.info("Deploying application", connector.getAmplMessagePublisher());
-                    NebulousAppDeployer.deployUnmodifiedApplication(app);
+                    app.deploy();
                 } else {
                     log.warn("Performance indicators not supplied, cannot deploy");
                 }

--- a/optimiser-controller/src/main/java/eu/nebulouscloud/optimiser/controller/NebulousAppDeployer.java
+++ b/optimiser-controller/src/main/java/eu/nebulouscloud/optimiser/controller/NebulousAppDeployer.java
@@ -219,7 +219,6 @@ public class NebulousAppDeployer {
         String appUUID = app.getUUID();
         String clusterName = app.getClusterName();
         if (!app.setStateDeploying()) {
-            // TODO: wait until we got the performance indicators from Marta
             log.error("Trying to deploy app that is in state {} (should be READY), aborting deployment",
                 app.getState().name());
             app.setStateFailed();
@@ -502,16 +501,6 @@ public class NebulousAppDeployer {
 
         app.setStateDeploymentFinished(componentRequirements, nodeCounts, componentNodeNames, nodeEdgeCandidates, rewritten);
         log.info("App deployment finished.");
-    }
-
-    /**
-     * Given an app, deploy the Kubevela file as specified in the initial app
-     * creation message.
-     *
-     * @param app the NebulOuS app object to deploy.
-     */
-    public static void deployUnmodifiedApplication(NebulousApp app) {
-        deployApplication(app, app.getOriginalKubevela());
     }
 
     /**


### PR DESCRIPTION
- [X] Run multiple app deployments in parallel (We don't bother setting up a thread pool, since (one assumes) there won't be thousands of parallel app deployments going on)
- [x] Create method `synchronized NebulousApp.deploy()` to avoid the possibility of having two deployments in parallel, even if I don't see how that would be possible