### PR TITLE
Handle serverless components

### DIFF
--- a/optimiser-controller/src/main/java/eu/nebulouscloud/optimiser/controller/AMPLGenerator.java
+++ b/optimiser-controller/src/main/java/eu/nebulouscloud/optimiser/controller/AMPLGenerator.java
@@ -41,7 +41,7 @@ public class AMPLGenerator {
      * @param kubevela the kubevela file, used to obtain default variable values.
      * @return AMPL code for the solver.
      */
-    public static String generateAMPL(NebulousApp app, ObjectNode kubevela) {
+    public static String generateAMPL(NebulousApp app, JsonNode kubevela) {
         final StringWriter result = new StringWriter();
         final PrintWriter out = new PrintWriter(result);
         out.format("# AMPL file for application '%s' with id %s%n", app.getName(), app.getUUID());
@@ -231,7 +231,7 @@ public class AMPLGenerator {
         return result;
     }
 
-    private static void generateVariablesSection(NebulousApp app, ObjectNode kubevela, PrintWriter out) {
+    private static void generateVariablesSection(NebulousApp app, JsonNode kubevela, PrintWriter out) {
         out.println("# Variables");
         for (final JsonNode p : app.getKubevelaVariables().values()) {
             ObjectNode param = (ObjectNode) p;

--- a/optimiser-controller/src/main/java/eu/nebulouscloud/optimiser/controller/NebulousApp.java
+++ b/optimiser-controller/src/main/java/eu/nebulouscloud/optimiser/controller/NebulousApp.java
@@ -195,7 +195,7 @@ public class NebulousApp {
 
     /** The KubeVela as it was most recently sent to the app's controller. */
     @Getter
-    private ObjectNode deployedKubevela = null;
+    private JsonNode deployedKubevela = null;
 
     /**
      * The EXN connector for this class.  At the moment all apps share the
@@ -379,7 +379,7 @@ public class NebulousApp {
     /** Set state from DEPLOYING to RUNNING and update app cluster information.
       * @return false if not in state deploying, otherwise true. */
     @Synchronized
-    public boolean setStateDeploymentFinished(Map<String, List<Requirement>> componentRequirements, Map<String, Integer> nodeCounts, Map<String, Set<String>> componentNodeNames, Map<String, NodeCandidate> nodeEdgeCandidates, ObjectNode deployedKubevela) {
+    public boolean setStateDeploymentFinished(Map<String, List<Requirement>> componentRequirements, Map<String, Integer> nodeCounts, Map<String, Set<String>> componentNodeNames, Map<String, NodeCandidate> nodeEdgeCandidates, JsonNode deployedKubevela) {
         if (state != State.DEPLOYING) {
             return false;
         } else {

--- a/optimiser-controller/src/test/resources/invalid-serverless-deployment.yaml
+++ b/optimiser-controller/src/test/resources/invalid-serverless-deployment.yaml
@@ -1,0 +1,29 @@
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: first-app
+spec:
+  components:
+    - name: helloworld
+      type: webservice
+      properties:
+        image: oamdev/helloworld-python:v1
+        env:
+          - name: "TARGET"
+            value: "KubeVela"
+        port: 8080
+    - name: serverless-backend
+      type: webservice
+      properties:
+        resources:
+          requests:
+            cpu: "2"    # Requests for CPU in cores
+            memory: "2Gi" # Requests for memory in GiB
+        replicas: 3   # Number of replicas
+    - name: backend
+      type: knative-serving
+      properties:
+        image: gcr.io/knative-samples/helloworld-go
+        env:
+          - name: TARGET
+            value: "Go Sample v1"

--- a/optimiser-controller/src/test/resources/serverless-deployment.yaml
+++ b/optimiser-controller/src/test/resources/serverless-deployment.yaml
@@ -1,0 +1,29 @@
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: first-app
+spec:
+  components:
+    - name: helloworld
+      type: webservice
+      properties:
+        image: oamdev/helloworld-python:v1
+        env:
+          - name: "TARGET"
+            value: "KubeVela"
+        port: 8080
+    - name: serverless-backend
+      type: serverless-platform
+      properties:
+        resources:
+          requests:
+            cpu: "2"    # Requests for CPU in cores
+            memory: "2Gi" # Requests for memory in GiB
+        replicas: 3   # Number of replicas
+    - name: backend
+      type: knative-serving
+      properties:
+        image: gcr.io/knative-samples/helloworld-go
+        env:
+          - name: TARGET
+            value: "Go Sample v1"


### PR DESCRIPTION
- Skip serverless components when allocating VMs

- Add node affinity traits to components with `type: knative-serving` to
  refer to a node with `type: serverless-platform`.

Fixes #14