### PR TITLE
Ask for unassigned and app-specific edge nodes

### DIFF
--- a/optimiser-controller/src/main/java/eu/nebulouscloud/optimiser/controller/NebulousAppDeployer.java
+++ b/optimiser-controller/src/main/java/eu/nebulouscloud/optimiser/controller/NebulousAppDeployer.java
@@ -414,7 +414,7 @@ public class NebulousAppDeployer {
         // Find node candidates
         List<NodeCandidate> controllerCandidates = conn.findNodeCandidatesMultiple(
             requirementsWithLocations(controllerRequirements, app.getUUID(),
-                app.getClouds(), ComponentLocationType.EDGE_AND_CLOUD),
+                app.getClouds(), ComponentLocationType.CLOUD_ONLY),
             appUUID);
         if (controllerCandidates.isEmpty()) {
             log.error("Could not find node candidates for requirements: {}, aborting deployment",


### PR DESCRIPTION
We only ask for edge nodes based on the following naming scheme:

- "Free" edge nodes, which are named `application_id|all-applications|<edge_device_id>`.

- Edge nodes dedicated to a specific app, named `application_id|<application_id>|<edge_device_id>`.