### PR TITLE
Precompute "safe" application name

### DIFF
--- a/optimiser-controller/src/main/java/eu/nebulouscloud/optimiser/controller/AMPLGenerator.java
+++ b/optimiser-controller/src/main/java/eu/nebulouscloud/optimiser/controller/AMPLGenerator.java
@@ -44,7 +44,7 @@ public class AMPLGenerator {
     public static String generateAMPL(NebulousApp app, JsonNode kubevela) {
         final StringWriter result = new StringWriter();
         final PrintWriter out = new PrintWriter(result);
-        out.format("# AMPL file for application '%s' with id %s%n", app.getName(), app.getUUID());
+        out.format("# AMPL file for application '%s' with id %s%n", app.getRawName(), app.getUUID());
         out.println();
 
         generateVariablesSection(app, kubevela, out);

--- a/optimiser-controller/src/main/java/eu/nebulouscloud/optimiser/controller/NebulousApp.java
+++ b/optimiser-controller/src/main/java/eu/nebulouscloud/optimiser/controller/NebulousApp.java
@@ -49,7 +49,13 @@ public class NebulousApp {
     private String UUID;
     /**
      * The app name, a user-readable string.  Not safe to assume that this is
-     * a unique value.
+     * a unique value.  Might contain whitespace, unicode and everything else
+     * a user can type into a form.
+     */
+    @Getter private String rawName;
+
+    /**
+     * A version of the app name that is safe to use as a filename.
      */
     @Getter private String name;
 
@@ -218,7 +224,8 @@ public class NebulousApp {
     // optimiser-controller/src/test/resources/
     public NebulousApp(JsonNode app_message, String kubevela_string, ExnConnector exnConnector) {
         this.UUID = app_message.at(uuid_path).textValue();
-        this.name = app_message.at(name_path).textValue();
+        this.rawName = app_message.at(name_path).textValue();
+        this.name = rawName.replaceAll("[^a-zA-Z0-9-_]", "_");
         this.state = State.NEW;
         this.clusterName = NebulousApps.calculateUniqueClusterName(this.UUID);
         this.originalAppMessage = app_message;

--- a/optimiser-controller/src/main/java/eu/nebulouscloud/optimiser/controller/NebulousAppDeployer.java
+++ b/optimiser-controller/src/main/java/eu/nebulouscloud/optimiser/controller/NebulousAppDeployer.java
@@ -346,13 +346,8 @@ public class NebulousAppDeployer {
             app.setStateFailed();
             return;
         }
-        // The application name is typed in by the user, and is used
-        // internally by SAL as an unquoted filename in a generated shell
-        // script. It shouldn't be this way but it is what it is.
-        String safeAppName = app.getName().replaceAll("[^a-zA-Z0-9-_]", "_");
         ExnConnector conn = app.getExnConnector();
         log.info("Starting initial deployment for application");
-
 
         // The overall flow:
         //
@@ -621,7 +616,7 @@ public class NebulousAppDeployer {
         // Deploy application
 
         log.info("Calling deployApplication");
-        long proActiveJobID = conn.deployApplication(appUUID, clusterName, safeAppName, rewritten_kubevela);
+        long proActiveJobID = conn.deployApplication(appUUID, clusterName, app.getName(), rewritten_kubevela);
         log.info("deployApplication returned ProActive Job ID {}", proActiveJobID);
         if (proActiveJobID == 0) {
             // 0 means conversion from long has failed (because of an invalid


### PR DESCRIPTION
Change `app.getName()` to return a string suitable to use as a filename. The app name as written by the user is accessible via `app.getRawName()`.

Fixes #33