### PR TITLE
Only use SyncedPublisher instances once

### DIFF
--- a/optimiser-controller/src/main/java/eu/nebulouscloud/optimiser/controller/Main.java
+++ b/optimiser-controller/src/main/java/eu/nebulouscloud/optimiser/controller/Main.java
@@ -168,12 +168,7 @@ public class Main implements Callable<Integer> {
                 activemq_host, activemq_port);
             activeMQConnector
               = new ExnConnector(activemq_host, activemq_port,
-                  activemq_user, activemq_password,
-                  new ConnectorHandler() {
-                    public void onReady(AtomicReference<Context> context) {
-                      log.info("Optimiser-controller connected to ActiveMQ");
-                    }
-                  });
+                  activemq_user, activemq_password);
         } else {
             log.debug("ActiveMQ login info not set, only operating locally.");
         }


### PR DESCRIPTION
- The SyncedPublisher class is not thread-safe, and cannot be used for more than one "in-flight" request.  Therefore, create one instance per query.

- Obtain the connection's Context via the callback handler passed into the Connector constructor.  This object is used to register and unregister SyncedPublisher instances at query time.

- Make sure we don't try to use the context object before the onReady handler sets it.

Fixes #38