### PR TITLE
Do not log env-var-script property of getCluster

### DIFF
--- a/optimiser-controller/src/main/java/eu/nebulouscloud/optimiser/controller/NebulousAppDeployer.java
+++ b/optimiser-controller/src/main/java/eu/nebulouscloud/optimiser/controller/NebulousAppDeployer.java
@@ -312,6 +312,7 @@ public class NebulousAppDeployer {
                 return false;
             } else {
                 if (!status.equals("submited" /* [sic] */)
+                    && !status.equals("submitted" /* SAL fixed the spelling at some point */)
                     && !status.equals("scaling")) {
                     // Better paranoid than sorry
                     log.warn("Unknown 'status' value in getCluster result: {}", status);


### PR DESCRIPTION
Also remove a spurious warning caused by SAL renaming one of the possible values of the `state` property.

Fixes #43