### PR TITLE
Convert KubeVela memory number to int in Constants block

### DIFF
--- a/nebulous-requirements-extractor/src/main/java/eu/nebulouscloud/optimiser/kubevela/KubevelaAnalyzer.java
+++ b/nebulous-requirements-extractor/src/main/java/eu/nebulouscloud/optimiser/kubevela/KubevelaAnalyzer.java
@@ -17,7 +17,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.Spliterator;
 import java.util.Spliterators;
 import java.util.stream.Collectors;
@@ -242,6 +241,15 @@ public class KubevelaAnalyzer {
             // no spec given
             return -1;
         }
+    }
+
+    /**
+     * Check if the number should be an integer.  CPU, memory, replica count
+     * should be integers.
+     */
+    public static boolean isKubevelaInteger(String meaning) {
+        List<String> integerMeanings = List.of("cpu", "memory", "replicas");
+        return integerMeanings.contains(meaning);
     }
 
     /**

--- a/optimiser-controller/src/main/java/eu/nebulouscloud/optimiser/controller/AMPLGenerator.java
+++ b/optimiser-controller/src/main/java/eu/nebulouscloud/optimiser/controller/AMPLGenerator.java
@@ -235,7 +235,6 @@ public class AMPLGenerator {
         out.println("# Variables");
         for (final JsonNode p : app.getKubevelaVariables().values()) {
             ObjectNode param = (ObjectNode) p;
-            List<String> integerMeanings = List.of("cpu", "memory", "replicas");
             String paramName = param.get("key").textValue();
             String paramPath = param.get("path").textValue();
             String paramType = param.get("type").textValue();
@@ -244,7 +243,8 @@ public class AMPLGenerator {
             // Even if these variables are sent over as "float", we know they
             // have to be treated as integers for kubevela (replicas, memory)
             // or SAL (cpu).  I.e., paramMeaning overrides paramType.
-            boolean shouldBeInt = paramType.equals("int") || integerMeanings.contains(paramMeaning);
+            boolean shouldBeInt = paramType.equals("int")
+                                  || KubevelaAnalyzer.isKubevelaInteger(paramMeaning);
             ObjectNode value = (ObjectNode)param.get("value");
             if (paramType.equals("int") || paramType.equals("float")) {
                 out.format("var %s", paramName);

--- a/optimiser-controller/src/main/java/eu/nebulouscloud/optimiser/controller/ExnConnector.java
+++ b/optimiser-controller/src/main/java/eu/nebulouscloud/optimiser/controller/ExnConnector.java
@@ -403,7 +403,7 @@ public class ExnConnector {
                 } else {
                     // This should be very quick, no need to start a thread
                     MDC.put("clusterName", app.getClusterName());
-                    app.sendAMPL();
+                    app.sendAMPL(app.calculateAMPLMessage());
                     app.sendMetricList(); // re-send for solver
                 }
             } finally {

--- a/optimiser-controller/src/main/java/eu/nebulouscloud/optimiser/controller/LocalExecution.java
+++ b/optimiser-controller/src/main/java/eu/nebulouscloud/optimiser/controller/LocalExecution.java
@@ -82,7 +82,12 @@ public class LocalExecution implements Callable<Integer> {
                 }
             } else {
                 log.info("No deploy requested, printing AMPL and performance metric list");
-                String ampl = AMPLGenerator.generateAMPL(app, app.getOriginalKubevela());
+                JsonNode solverMessage = app.calculateAMPLMessage();
+                String ampl = solverMessage.at("/ModelFileContent").asText();
+                System.out.println("--------------------");
+                System.out.println("Message");
+                System.out.println("--------------------");
+                System.out.println(solverMessage.toPrettyString());
                 System.out.println("--------------------");
                 System.out.println("AMPL");
                 System.out.println("--------------------");


### PR DESCRIPTION
- Convert "8Gi" to 8192.

- Refactor to use the same code path during AMPL generation and in the Constants block.

- Refactor creation of message to solver into own, side-effect-free method for testing

- When running optimiser-controller locally with app message in file, print both the whole solver message and the AMPL file.

Fixes #42