### PR TITLE
Send cluster status while deploying

### DIFF
--- a/optimiser-controller/src/main/java/eu/nebulouscloud/optimiser/controller/ExnConnector.java
+++ b/optimiser-controller/src/main/java/eu/nebulouscloud/optimiser/controller/ExnConnector.java
@@ -1023,4 +1023,24 @@ public class ExnConnector {
         appStatusPublisher.send(msg, appID);
     }
 
+    /**
+     * Broadcasts an application's state, with an auxiliary data value
+     * attached.<p>
+     *
+     * Messages are in the same form as sent by {@link #sendAppStatus(String,
+     * NebulousApp.State)} but with an additional {@code key: value} entry in
+     * the status message.
+     *
+     * @param appID the application id.
+     * @param state the state of the application.
+     * @param key the key of an additional entry in the status message
+     * @param value the value of an additional entry in the status message
+     */
+    public void sendAppStatus(String appID, NebulousApp.State state, String key, JsonNode value) {
+        Map<String, Object> msg = Map.of(
+            "state", state.toString(),
+            key, mapper.convertValue(value, Map.class));
+        appStatusPublisher.send(msg, appID);
+    }
+
 }

--- a/optimiser-controller/src/main/java/eu/nebulouscloud/optimiser/controller/NebulousApp.java
+++ b/optimiser-controller/src/main/java/eu/nebulouscloud/optimiser/controller/NebulousApp.java
@@ -389,6 +389,24 @@ public class NebulousApp {
         }
     }
 
+    /**
+     * If app is in the DEPLOYING state, sends a DEPLOYING state message, with
+     * the cluster status as reported by SAL.  Otherwise does nothing.
+     *
+     * @param clusterStatus a JSON node with the cluster status returned by
+     *  the getCluster endpoint.
+     * @return true if status message sent, false otherwise.
+     */
+    @Synchronized
+    public boolean sendDeploymentStatus(JsonNode clusterState) {
+        if (state == State.DEPLOYING) {
+            exnConnector.sendAppStatus(UUID, state, "clusterState", clusterState);
+            return true;
+        } else {
+            return false;
+        }
+    }
+
     /** Set state from DEPLOYING to RUNNING and update app cluster information.
       * @return false if not in state deploying, otherwise true. */
     @Synchronized


### PR DESCRIPTION
While the cluster is starting or reconfiguring during deployment and redeployment, we'll send out periodic messages to the `eu.nebulouscloud.optimiser.controller.app_state` channel of the following form:

```
{
  "when": "2024-04-17T07:54:00.169580700Z",
  "state": "DEPLOYING",
  "clusterState": { ... }
}
```

If the `clusterState` key exists, its value will be the return value of SAL's getCluster endpoint.  The value format is defined in the sal-common class `Cluster`; see
https://github.com/ow2-proactive/scheduling-abstraction-layer/blob/master/sal-common/src/main/java/org/ow2/proactive/sal/model/Cluster.java

Note that the `clusterState` key may be missing from the status message; this is the case when deployment or redeployment has been triggered but the optimiser-controller is still calculating the necessary changes to the cluster.