### PR TITLE
Use sal-common cluster state string constants

### DIFF
--- a/optimiser-controller/src/main/java/eu/nebulouscloud/optimiser/controller/NebulousAppDeployer.java
+++ b/optimiser-controller/src/main/java/eu/nebulouscloud/optimiser/controller/NebulousAppDeployer.java
@@ -33,6 +33,28 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class NebulousAppDeployer {
 
+    // Copied verbatim from
+    // https://github.com/ow2-proactive/scheduling-abstraction-layer/blob/master/sal-service/src/main/java/org/ow2/proactive/sal/service/service/ClusterService.java
+    // since there is no public definition or documentation of the cluster
+    // state values
+
+    // BEGIN COPY
+
+    // Define cluster state constants
+    private static final String STATUS_DEFINED = "Defined";
+
+    private static final String STATUS_DEPLOYED = "Deployed";
+
+    private static final String STATUS_FAILED = "Failed";
+
+    private static final String STATUS_SUBMITTED = "Submitted"; // New status
+
+    private static final String STATUS_SCALING = "Scaling";
+
+    private static final String STATUS_FINISHED = "Finished";
+
+    // END COPY
+
     private static final ObjectMapper yamlMapper
         = new ObjectMapper(YAMLFactory.builder().build());
     private static final ObjectMapper mapper = new ObjectMapper();
@@ -304,16 +326,15 @@ public class NebulousAppDeployer {
                 // Forget about intermittent failures
                 failedCalls = 0;
             }
-            if (status.equals("deployed")) {
+            if (status.equals(STATUS_DEPLOYED)) {
                 log.info("Cluster deployment finished successfully");
                 return true;
-            } else if (status.equals("failed")) {
+            } else if (status.equals(STATUS_FAILED)) {
                 log.warn("Cluster deployment failed");
                 return false;
             } else {
-                if (!status.equals("submited" /* [sic] */)
-                    && !status.equals("submitted" /* SAL fixed the spelling at some point */)
-                    && !status.equals("scaling")) {
+                if (!status.equals(STATUS_SUBMITTED)
+                    && !status.equals(STATUS_SCALING)) {
                     // Better paranoid than sorry
                     log.warn("Unknown 'status' value in getCluster result: {}", status);
                 }


### PR DESCRIPTION
- Copy definitions from https://github.com/ow2-proactive/scheduling-abstraction-layer/blob/master/sal-service/src/main/java/org/ow2/proactive/sal/service/service/ClusterService.java since these values are not exported by SAL

Fixes https://github.com/eu-nebulous/nebulous/issues/58