### PR TITLE
Support ActiveMQ-less local execution

### DIFF
--- a/optimiser-controller/src/main/java/eu/nebulouscloud/optimiser/controller/LocalExecution.java
+++ b/optimiser-controller/src/main/java/eu/nebulouscloud/optimiser/controller/LocalExecution.java
@@ -97,8 +97,6 @@ public class LocalExecution implements Callable<Integer> {
                 System.out.println("--------------------");
                 AMPLGenerator.getMetricList(app).forEach(System.out::println);
             }
-        }
-        if (connector != null) {
             if (keepalive) {
                 try {
                     exn_synchronizer.await();
@@ -114,6 +112,22 @@ public class LocalExecution implements Callable<Integer> {
                 // exn-connector-java throws spurious Groovy-internal error
                 // when stopping; let's not crash in the end
             }
+        } else {
+            log.info("Not connected to ActiveMQ, printing AMPL and (if given) performance metric list");
+            JsonNode solverMessage = app.calculateAMPLMessage();
+            String ampl = solverMessage.at("/ModelFileContent").asText();
+            System.out.println("--------------------");
+            System.out.println("Message");
+            System.out.println("--------------------");
+            System.out.println(solverMessage.toPrettyString());
+            System.out.println("--------------------");
+            System.out.println("AMPL");
+            System.out.println("--------------------");
+            System.out.println(ampl);
+            System.out.println("--------------------");
+            System.out.println("Metrics");
+            System.out.println("--------------------");
+            AMPLGenerator.getMetricList(app).forEach(System.out::println);
         }
         return 0;
     }


### PR DESCRIPTION
The use case for this change is to support local creation of AMPL code from app creation messages recorded as files.