### PR TITLE
Ignore busy edge nodes while filtering node candidates

### DIFF
--- a/optimiser-controller/src/main/java/eu/nebulouscloud/optimiser/controller/NebulousApp.java
+++ b/optimiser-controller/src/main/java/eu/nebulouscloud/optimiser/controller/NebulousApp.java
@@ -445,7 +445,10 @@ public class NebulousApp {
     @Synchronized
     public boolean sendDeploymentStatus(JsonNode clusterState) {
         if (state == State.DEPLOYING) {
-            exnConnector.sendAppStatus(UUID, state, Map.of("clusterState", clusterState));
+            exnConnector.sendAppStatus(UUID, state
+                // FIXME convert this to something that doesn't crash the middleware.  Comment out for now.
+                // , Map.of("clusterState", clusterState)
+            );
             return true;
         } else {
             return false;

--- a/optimiser-controller/src/main/java/eu/nebulouscloud/optimiser/controller/NebulousAppDeployer.java
+++ b/optimiser-controller/src/main/java/eu/nebulouscloud/optimiser/controller/NebulousAppDeployer.java
@@ -592,7 +592,8 @@ public class NebulousAppDeployer {
             while (nodeNumber < numberOfNodes) {
                 String nodeName = createNodeName(clusterName, componentName, app.getDeployGeneration(), nodeNumber);
                 NodeCandidate candidate = candidates.stream()
-                    .filter(each -> !EdgeNodes.ownedEdgeNodes(appUUID).contains(each))
+                    .filter(each -> !isEdgeNodeBusy(each)
+                                    && !EdgeNodes.ownedEdgeNodes(appUUID).contains(each))
                     .findFirst()
                     .orElse(null);
                 if (candidate == null) {
@@ -867,7 +868,8 @@ public class NebulousAppDeployer {
                     while (nodeNumber <= nAdd) {
                         String nodeName = createNodeName(clusterName, componentName, app.getDeployGeneration(), nodeNumber);
                         NodeCandidate candidate = candidates.stream()
-                            .filter(each -> !EdgeNodes.ownedEdgeNodes(appUUID).contains(each))
+                            .filter(each -> !isEdgeNodeBusy(each)
+                                            && !EdgeNodes.ownedEdgeNodes(appUUID).contains(each))
                             .findFirst()
                             .orElse(null);
                         if (candidate == null) {
@@ -941,7 +943,8 @@ public class NebulousAppDeployer {
                 while (nodeNumber <= componentReplicaCounts.get(componentName)) {
                     String nodeName = createNodeName(clusterName, componentName, app.getDeployGeneration(), nodeNumber);
                     NodeCandidate candidate = candidates.stream()
-                        .filter(each -> !EdgeNodes.ownedEdgeNodes(appUUID).contains(each))
+                        .filter(each -> !isEdgeNodeBusy(each)
+                                        && !EdgeNodes.ownedEdgeNodes(appUUID).contains(each))
                         .findFirst()
                         .orElse(null);
                     if (candidate == null) {


### PR DESCRIPTION
Also temporarily remove cluster status from DEPLOYING message; to be fixed later