### PR TITLE
Fix race condition during deployment

### DIFF
--- a/optimiser-controller/src/main/java/eu/nebulouscloud/optimiser/controller/LocalExecution.java
+++ b/optimiser-controller/src/main/java/eu/nebulouscloud/optimiser/controller/LocalExecution.java
@@ -68,6 +68,7 @@ public class LocalExecution implements Callable<Integer> {
             return 1;
         }
         NebulousApp app = NebulousApp.newFromAppMessage(app_msg, connector);
+        NebulousApps.add(app);
         MDC.put("appId", app.getUUID());
         MDC.put("clusterName", app.getClusterName());
         if (perf_msg != null)

--- a/optimiser-controller/src/main/java/eu/nebulouscloud/optimiser/controller/NebulousApp.java
+++ b/optimiser-controller/src/main/java/eu/nebulouscloud/optimiser/controller/NebulousApp.java
@@ -336,7 +336,11 @@ public class NebulousApp {
 
     /**
      * Create a NebulousApp object given an app creation message parsed into
-     * JSON, and register it via {@link NebulousApps#add}.
+     * JSON.
+     *
+     * <p>Note that the result should be registered via {@link
+     * NebulousApps#add} afterwards.  This is not done automatically since
+     * registering an app happens on the hot path inside a mutex.
      *
      * @param app_message the app creation message, including valid KubeVela
      *  YAML et al
@@ -356,7 +360,6 @@ public class NebulousApp {
             } else {
                 Main.logFile("incoming-kubevela-" + UUID + ".yaml", kubevela_string);
                 NebulousApp result = new NebulousApp(app_message, kubevela_string, exnConnector);
-                NebulousApps.add(result);
                 return result;
             }
         } catch (Exception e) {

--- a/optimiser-controller/src/test/java/eu/nebulouscloud/optimiser/controller/NebulousAppTests.java
+++ b/optimiser-controller/src/test/java/eu/nebulouscloud/optimiser/controller/NebulousAppTests.java
@@ -41,7 +41,9 @@ public class NebulousAppTests {
         String app_message_string = Files.readString(getResourcePath(filename),
             StandardCharsets.UTF_8);
         JsonNode msg = mapper.readTree(app_message_string);
-        return NebulousApp.newFromAppMessage(msg, null);
+        NebulousApp result = NebulousApp.newFromAppMessage(msg, null);
+        NebulousApps.add(result);
+        return result;
     }
 
     @Test


### PR DESCRIPTION
Make sure that metric and dsl messages can't cross in a way that both `AppCreationMessageHandler` and `PerformanceIndicatorMessageHandler` do not find the object created by the other handler.

Change `NebulousApp.newFromAppMessage` to not register its result in `NebulousApps`, to minimize the time we spend in the mutex.  Add `NebulousApps.add` calls where we relied on this behavior.

Fixes #74