### PR TITLE
Ignore unreferenced variables in solver solution

### DIFF
--- a/optimiser-controller/src/main/java/eu/nebulouscloud/optimiser/controller/NebulousApp.java
+++ b/optimiser-controller/src/main/java/eu/nebulouscloud/optimiser/controller/NebulousApp.java
@@ -628,7 +628,11 @@ public class NebulousApp {
             String key = entry.getKey();
             JsonNode replacementValue = entry.getValue();
             JsonNode param = kubevelaVariables.get(key);
-            JsonPointer path = kubevelaVariablePaths.get(key);
+            JsonPointer path = kubevelaVariablePaths.getOrDefault(key, null);
+            // The solver puts all variables into the solution message,
+            // including ones that are not referenced in the KubeVela file --
+            // ignore those.
+            if (path == null) continue;
             JsonNode nodeToBeReplaced = freshKubevela.at(path);
             boolean doReplacement = true;
 


### PR DESCRIPTION
The solver sends all AMPL variables in its solution message; in nontrivial cases, not all of these will reference locations in the app's Kubevela definition.  Ignore such unreferenced variables when rewriting the Kubevela definition with the solver's solution.