### PR TITLE
Use updated location for exn-connector-java middleware

### DIFF
--- a/optimiser-controller/build.gradle
+++ b/optimiser-controller/build.gradle
@@ -31,7 +31,12 @@ repositories {
     }
     // NebulOuS-developed components
     maven {
-        url = 'https://s01.oss.sonatype.org/content/repositories/snapshots/'
+        name = 'Central Portal Snapshots'
+        url = 'https://central.sonatype.com/repository/maven-snapshots/'
+        // Only search this repository for the specific dependency
+        content {
+            includeModule("io.github.eu-nebulous", "exn-connector-java")
+        }
     }
 }
 


### PR DESCRIPTION
This fixes one of two dependency problems; note that the build still fails because sal-common is not yet available