### PR TITLE
Fix group id for exn-connector-java

### DIFF
--- a/optimiser-controller/build.gradle
+++ b/optimiser-controller/build.gradle
@@ -28,7 +28,7 @@ repositories {
     maven {
         url "https://s01.oss.sonatype.org/content/repositories/snapshots/"
         content {
-            includeModule("eu.nebulouscloud", "exn-connector-java")
+            includeModule("io.github.eu-nebulous", "exn-connector-java")
         }
        }
     
@@ -55,7 +55,7 @@ dependencies {
 
     // the EXN Middleware:
     // https://openproject.nebulouscloud.eu/projects/nebulous-collaboration-hub/wiki/asynchronous-messaging-specification
-    implementation('eu.nebulouscloud:exn-connector-java:1.0-SNAPSHOT') {
+    implementation('io.github.eu-nebulous:exn-connector-java:1.0-SNAPSHOT') {
         exclude group: 'org.slf4j', module: 'slf4j-simple'
         changing = true
     }


### PR DESCRIPTION
Note that the build fails at the time or merging because oss.sonatype.org currently gives 504 errors